### PR TITLE
properly align the footer at the bottom of the page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,8 @@
       </div>
     </main>
 
+    <div style="flex-grow: 1;"></div>
+
     {%- include footer.html -%}
 
   </body>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,6 +1,16 @@
 ---
 # Only the main Sass file needs front matter (the dashes are enough)
 ---
+
+html, body {
+  height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
 .navbar-portalname a {
     color: #383838;
     text-decoration: none;
@@ -18,7 +28,7 @@ div.highlight {
 main {
   padding-top: 80px;
   padding-bottom: 80px;
-  min-height: 700px;
+  //min-height: 700px;
 }
 
 .post {


### PR DESCRIPTION
This pull request replaces the `min-height` attribute on the main section with `display: flex` on the body. This ensures the footer is at the bottom at all times.
The `display: flex` and `flex-grow: 1;` causes the `<div style="flex-grow: 1;"></div>` to eat up all the available space.

I'm a new member of the OTC team btw. ;)