### PR TITLE
better main column

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,7 +9,7 @@ layout: default
 
 {%- if site.posts.size > 0 -%}
   <div class="row content-1">
-    <div class="col-l-8 col-s-12">
+    <div class="col-xl-8 offset-xl-2 col-l-12">
       {% for post in site.posts %}
         <div class="post">
           <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 <div class="row content-1">
-  <div class="col-l-8 col-s-12">
+  <div class="col-xl-8 offset-xl-2 col-l-12">
     <article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
 
       <header class="post-header">


### PR DESCRIPTION
This improves the main column. It keeps it full width for `l` screens and below (the navigation behaves the same) and changes to a width of 8 on `xl` screens that is centered (the navigation behaves like that as well).