### PR TITLE
define categories in posts as yaml list

### DIFF
--- a/_posts/2018-04-17-openshift-blueprint.md
+++ b/_posts/2018-04-17-openshift-blueprint.md
@@ -2,7 +2,9 @@
 layout: post
 title:  "Get OpenShift Origin 3.7 on Fedora 27 Atomic running on Open Telekom Cloud"
 date:   2018-04-17 08:00:00 +0100
-categories: otc, blueprints
+categories:
+  - otc
+  - blueprints
 author: A. Goncharov
 excerpt_separator: <!--excerpt-->
 ---


### PR DESCRIPTION
Post categories need to be defined as yaml list or space separated string. As yaml lists are a little clearer I chose them over space separated strings. The `,` messes up the url.
https://jekyllrb.com/docs/frontmatter/#predefined-variables-for-posts